### PR TITLE
Fix URL for temporary website

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,6 +5,7 @@ command = "hugo"
 [context.production.environment]
 HUGO_VERSION = "0.88.1"
 HUGO_ENV = "production"
+command = "hugo -b $URL"
 
 [context.deploy-preview]
 command = "hugo -b $DEPLOY_PRIME_URL"


### PR DESCRIPTION
Until we deploy the website as https://antrea.io

Signed-off-by: Antonin Bas <abas@vmware.com>