### PR TITLE
Fix error when syncing doc dir

### DIFF
--- a/scripts/pkg/update-docs.go
+++ b/scripts/pkg/update-docs.go
@@ -47,6 +47,11 @@ func CopyFile(source, dest string) error {
 	}
 	defer in.Close()
 
+	dir := filepath.Dir(dest)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+
 	out, err := os.Create(dest)
 	if err != nil {
 		return err


### PR DESCRIPTION
The script should ensure the destination directory exist before copying
the file.

Signed-off-by: Quan Tian <qtian@vmware.com>