### PR TITLE
Add link to security document in TOC for main and v1.6

### DIFF
--- a/data/docs/main-toc.yml
+++ b/data/docs/main-toc.yml
@@ -35,6 +35,8 @@ toc:
         url: /docs/traffic-encryption
       - page: Securing Control Plane
         url: /docs/securing-control-plane
+      - page: Security considerations
+        url: /docs/security
       - page: Troubleshooting
         url: /docs/troubleshooting
       - page: OS-specific Known Issues

--- a/data/docs/v1.6.0-toc.yml
+++ b/data/docs/v1.6.0-toc.yml
@@ -35,6 +35,8 @@ toc:
         url: /docs/traffic-encryption
       - page: Securing Control Plane
         url: /docs/securing-control-plane
+      - page: Security considerations
+        url: /docs/security
       - page: Troubleshooting
         url: /docs/troubleshooting
       - page: OS-specific Known Issues


### PR DESCRIPTION
Signed-off-by: Antonin Bas <abas@vmware.com>