### PR TITLE
Add Helm repo index for Antrea chart

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -44,6 +44,17 @@ jobs:
         TAG: ${{ github.event.inputs.antrea-ref }}
       run: |
         ./website/scripts/bin/freeze-version-docs -antrea-repo antrea -website-repo website -version $TAG
+    - name: Update Helm index file
+      if: ${{ github.event.inputs.antrea-ref != 'main' }}
+      env:
+        TAG: ${{ github.event.inputs.antrea-ref }}
+      run: |
+        function version_lt() { test "$(printf '%s\n' "$@" | sort -rV | head -n 1)" != "$1"; }
+        if version_lt $TAG "v1.8.0"; then
+            echo "Antrea version < v1.8.0, skipping Helm index update"
+            exit 0
+        fi
+        ./website/scripts/update-helm-index.sh -website-repo website -version $TAG
     - name: Commit changes as antrea-bot
       uses: EndBug/add-and-commit@v7
       with:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -54,7 +54,7 @@ jobs:
             echo "Antrea version < v1.8.0, skipping Helm index update"
             exit 0
         fi
-        ./website/scripts/update-helm-index.sh -website-repo website -version $TAG
+        ./website/scripts/update-helm-index.sh --website-repo website --version $TAG
     - name: Commit changes as antrea-bot
       uses: EndBug/add-and-commit@v7
       with:

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,2 +1,3 @@
 bin
 .golangci-bin
+.bin

--- a/scripts/update-helm-index.sh
+++ b/scripts/update-helm-index.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 Antrea Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+function echoerr {
+    >&2 echo "$@"
+}
+
+_usage="Usage: $0 [--antrea-repo-url <URL>] --website-repo <DIR> --version <VERSION>
+Update the Helm repo index file."
+
+function print_usage {
+    echoerr "$_usage"
+}
+
+function print_help {
+    echoerr "Try '$0 --help' for more information."
+}
+
+ANTREA_REPO_URL="https://github.com/antrea-io/antrea"
+WEBSITE_REPO=""
+VERSION=""
+
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+    --antrea-repo-url)
+    ANTREA_REPO_URL="$2"
+    shift 2
+    ;;
+    --website-repo)
+    WEBSITE_REPO="$2"
+    shift 2
+    ;;
+    --version)
+    VERSION="$2"
+    shift 2
+    ;;
+    -h|--help)
+    print_usage
+    exit 0
+    ;;
+    *)    # unknown option
+    echoerr "Unknown option $1"
+    exit 1
+    ;;
+esac
+done
+
+if [ "$WEBSITE_REPO" == "" ]; then
+    echoerr "--website-repo is required"
+    print_help
+    exit 1
+fi
+
+if [ "$VERSION" == "" ]; then
+    echoerr "--version is required"
+    print_help
+    exit 1
+fi
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+source $THIS_DIR/verify-helm.sh
+
+if [ -z "$HELM" ]; then
+    HELM="$(verify_helm)"
+elif ! $HELM version > /dev/null 2>&1; then
+    echoerr "$HELM does not appear to be a valid helm binary"
+    print_help
+    exit 1
+fi
+
+TMP_DIR=$(mktemp -d archives.XXXXXXXX)
+
+RELEASE_ASSETS_URL="$ANTREA_REPO_URL/releases/download/$VERSION"
+ARCHIVE_URL="$RELEASE_ASSETS_URL/antrea-chart.tgz"
+INDEX_PATH="$WEBSITE_REPO/static/charts/index.yaml"
+
+curl -sLo "$TMP_DIR/antrea-${VERSION:1}.tgz" "$ARCHIVE_URL"
+
+$HELM repo index $TMP_DIR --merge $INDEX_PATH --url $RELEASE_ASSETS_URL
+
+mv "$TMP_DIR/index.yaml" $INDEX_PATH
+
+rm -rf $TMP_DIR

--- a/scripts/update-helm-index.sh
+++ b/scripts/update-helm-index.sh
@@ -93,7 +93,7 @@ RELEASE_ASSETS_URL="$ANTREA_REPO_URL/releases/download/$VERSION"
 ARCHIVE_URL="$RELEASE_ASSETS_URL/antrea-chart.tgz"
 INDEX_PATH="$WEBSITE_REPO/static/charts/index.yaml"
 
-curl -sLo "$TMP_DIR/antrea-${VERSION:1}.tgz" "$ARCHIVE_URL"
+curl -sLo "$TMP_DIR/antrea-chart.tgz" "$ARCHIVE_URL"
 
 $HELM repo index $TMP_DIR --merge $INDEX_PATH --url $RELEASE_ASSETS_URL
 

--- a/scripts/verify-helm.sh
+++ b/scripts/verify-helm.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 Antrea Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+_BINDIR="$THIS_DIR/.bin"
+# Must be an exact match, as the generated YAMLs may not be consistent across
+# versions
+_HELM_VERSION="v3.8.1"
+
+# Ensure the helm tool exists and is the correct version, or install it
+verify_helm() {
+    # Check if there is already a helm binary in $_BINDIR and if yes, check if
+    # the version matches the expected one.
+    local helm="$(PATH=$_BINDIR command -v helm)"
+    if [ -x "$helm" ]; then
+        # Verify version if helm was already installed.
+        local helm_version="$($helm version --short 2> >(grep -v 'This is insecure' >&2))"
+        # Should work with:
+        #  - v3.8.1
+        #  - v3.8.1+g5cb9af4
+        helm_version="${helm_version%+*}"
+        if [ "${helm_version}" == "${_HELM_VERSION}" ]; then
+            # If version is exact match, stop here.
+            echo "$helm"
+            return 0
+        fi
+        >&2 echo "Detected helm version ($helm_version) does not match expected one ($_HELM_VERSION), installing correct version"
+    fi
+    local ostype=""
+    if [[ "$OSTYPE" == "linux-gnu" ]]; then
+        ostype="linux"
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        ostype="darwin"
+    else
+        >&2 echo "Unsupported OS type $OSTYPE"
+        return 1
+    fi
+    rc=0
+    local unameArch="$(uname -m)" || rc=$?
+    if [ $rc -ne 0 ]; then
+        >&2 echo "Cannot detect architecture type, uname not available?"
+        return 1
+    fi
+    local arch=""
+    case "$unameArch" in
+        x86_64) arch="amd64";;
+        arm64) arch="arm64";;
+        *) >&2 echo "Unsupported architecture type $unameArch"; return 1;;
+    esac
+    
+    >&2 echo "Installing helm"
+    local helm_url="https://get.helm.sh/helm-${_HELM_VERSION}-${ostype}-${arch}.tar.gz"
+    curl -sLo helm.tar.gz "${helm_url}" || return 1
+    mkdir -p "$_BINDIR" || return 1
+    tar -xzf helm.tar.gz -C "$_BINDIR" --strip-components=1 "${ostype}-${arch}/helm" || return 1
+    rm -f helm.tar.gz
+    helm="$_BINDIR/helm"
+    echo "$helm"
+    return 0
+}

--- a/static/_redirects
+++ b/static/_redirects
@@ -9,3 +9,5 @@
 # Other redirects
 # Github page with information about Antrea "live" office hours
 /live https://github.com/jayunit100/k8sprototypes/blob/master/antrea-LIVE/README.md 200
+
+https://charts.antrea.io/* https://antrea.io/charts/:splat

--- a/static/charts/index.yaml
+++ b/static/charts/index.yaml
@@ -1,0 +1,1 @@
+apiVersion: v1


### PR DESCRIPTION
* repo URL is https://antrea.io/charts or https://charts.antrea.io
* index is updated for every Antrea release starting with v1.8

For https://github.com/antrea-io/antrea/issues/2641

Signed-off-by: Antonin Bas <abas@vmware.com>