### PR TITLE
Move Helm index update to its own workflow

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -12,6 +12,8 @@ on:
         required: false
         default: 'main'
 
+concurrency: needs_to_commit
+
 jobs:
   update:
     runs-on: ubuntu-latest
@@ -44,17 +46,6 @@ jobs:
         TAG: ${{ github.event.inputs.antrea-ref }}
       run: |
         ./website/scripts/bin/freeze-version-docs -antrea-repo antrea -website-repo website -version $TAG
-    - name: Update Helm index file
-      if: ${{ github.event.inputs.antrea-ref != 'main' }}
-      env:
-        TAG: ${{ github.event.inputs.antrea-ref }}
-      run: |
-        function version_lt() { test "$(printf '%s\n' "$@" | sort -rV | head -n 1)" != "$1"; }
-        if version_lt $TAG "v1.8.0"; then
-            echo "Antrea version < v1.8.0, skipping Helm index update"
-            exit 0
-        fi
-        ./website/scripts/update-helm-index.sh --website-repo website --version $TAG
     - name: Commit changes as antrea-bot
       uses: EndBug/add-and-commit@v7
       with:

--- a/.github/workflows/update_helm_index.yml
+++ b/.github/workflows/update_helm_index.yml
@@ -1,0 +1,33 @@
+name: Update Helm index
+
+on:
+  workflow_dispatch:
+    inputs:
+      archive-url:
+        description: 'URL to the Helm archive (e.g., https://github.com/antrea-io/antrea/releases/download/v1.8.0/antrea-chart.tgz)'
+        required: true
+
+concurrency: needs_to_commit
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+      with:
+        path: website
+        token: ${{ secrets.ANTREA_BOT_PAT }}
+    - name: Update Helm index file
+      env:
+        ARCHIVE_URL: ${{ github.event.inputs.archive-url }}
+      run: |
+        ./website/scripts/update-helm-index.sh --website-repo website --archive-url $ARCHIVE_URL
+    - name: Commit changes as antrea-bot
+      uses: EndBug/add-and-commit@v7
+      with:
+        cwd: ./website
+        author_name: antrea-bot
+        author_email: antreabot@gmail.com
+        message: "Helm index update for ${{ github.event.inputs.archive-url }}"
+        signoff: false

--- a/scripts/update-helm-index.sh
+++ b/scripts/update-helm-index.sh
@@ -20,7 +20,7 @@ function echoerr {
     >&2 echo "$@"
 }
 
-_usage="Usage: $0 [--antrea-repo-url <URL>] --website-repo <DIR> --version <VERSION>
+_usage="Usage: $0 --website-repo <DIR> --archive-url <URL>
 Update the Helm repo index file."
 
 function print_usage {
@@ -31,25 +31,20 @@ function print_help {
     echoerr "Try '$0 --help' for more information."
 }
 
-ANTREA_REPO_URL="https://github.com/antrea-io/antrea"
 WEBSITE_REPO=""
-VERSION=""
+ARCHIVE_URL=""
 
 while [[ $# -gt 0 ]]
 do
 key="$1"
 
 case $key in
-    --antrea-repo-url)
-    ANTREA_REPO_URL="$2"
-    shift 2
-    ;;
     --website-repo)
     WEBSITE_REPO="$2"
     shift 2
     ;;
-    --version)
-    VERSION="$2"
+    --archive-url)
+    ARCHIVE_URL="$2"
     shift 2
     ;;
     -h|--help)
@@ -69,8 +64,8 @@ if [ "$WEBSITE_REPO" == "" ]; then
     exit 1
 fi
 
-if [ "$VERSION" == "" ]; then
-    echoerr "--version is required"
+if [ "$ARCHIVE_URL" == "" ]; then
+    echoerr "--archive-url is required"
     print_help
     exit 1
 fi
@@ -89,13 +84,13 @@ fi
 
 TMP_DIR=$(mktemp -d archives.XXXXXXXX)
 
-RELEASE_ASSETS_URL="$ANTREA_REPO_URL/releases/download/$VERSION"
-ARCHIVE_URL="$RELEASE_ASSETS_URL/antrea-chart.tgz"
 INDEX_PATH="$WEBSITE_REPO/static/charts/index.yaml"
+ARCHIVE_NAME=$(basename "$ARCHIVE_URL")
+BASE_URL=$(dirname "$ARCHIVE_URL")
 
-curl -sSfLo "$TMP_DIR/antrea-chart.tgz" "$ARCHIVE_URL"
+curl -sSfLo "$TMP_DIR/$ARCHIVE_NAME" "$ARCHIVE_URL"
 
-$HELM repo index $TMP_DIR --merge $INDEX_PATH --url $RELEASE_ASSETS_URL
+$HELM repo index $TMP_DIR --merge $INDEX_PATH --url $BASE_URL
 
 mv "$TMP_DIR/index.yaml" $INDEX_PATH
 


### PR DESCRIPTION
I realized (a bit late) that it made more sense to have this as its own
workflow:
* easier to support charts which are not hosted in the Antrea main repo
  (e.g. Theia chart)
* ability to run the workflow manually if needed, independently of other
  website updates
* unlike regular website updates, the workflow only needs to run for
  releases (not updates to the Antrea main branch)

Signed-off-by: Antonin Bas <abas@vmware.com>