### PR TITLE
Remove "needs_to_commit" concurrency group

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -12,8 +12,6 @@ on:
         required: false
         default: 'main'
 
-concurrency: needs_to_commit
-
 jobs:
   update:
     runs-on: ubuntu-latest
@@ -29,6 +27,11 @@ jobs:
       with:
         path: website
         token: ${{ secrets.ANTREA_BOT_PAT }}
+    - name: Wait for exclusive access
+      working-directory: website
+      uses: ben-z/gh-action-mutex@v1.0-alpha-5
+      with:
+          branch: needs_to_commit-mutex
     - name: Install golang
       uses: actions/setup-go@v2
       with:

--- a/.github/workflows/update_helm_index.yml
+++ b/.github/workflows/update_helm_index.yml
@@ -7,8 +7,6 @@ on:
         description: 'URL to the Helm archive (e.g., https://github.com/antrea-io/antrea/releases/download/v1.8.0/antrea-chart.tgz)'
         required: true
 
-concurrency: needs_to_commit
-
 jobs:
   update:
     runs-on: ubuntu-latest
@@ -18,6 +16,11 @@ jobs:
       with:
         path: website
         token: ${{ secrets.ANTREA_BOT_PAT }}
+    - name: Wait for exclusive access
+      working-directory: website
+      uses: ben-z/gh-action-mutex@v1.0-alpha-5
+      with:
+          branch: needs_to_commit-mutex
     - name: Update Helm index file
       env:
         ARCHIVE_URL: ${{ github.event.inputs.archive-url }}


### PR DESCRIPTION
My understanding of concurrency groups was wrong and it will cause other
workflows in the same concurrency group to be cancelled, with no option
to change this behavior so far.

I didn't find any great solution so I am using
https://github.com/ben-z/gh-action-mutex for now.

Signed-off-by: Antonin Bas <abas@vmware.com>