### PR TITLE
Fix invalid workflows

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -28,7 +28,6 @@ jobs:
         path: website
         token: ${{ secrets.ANTREA_BOT_PAT }}
     - name: Wait for exclusive access
-      working-directory: website
       uses: ben-z/gh-action-mutex@v1.0-alpha-5
       with:
           branch: needs_to_commit-mutex

--- a/.github/workflows/update_helm_index.yml
+++ b/.github/workflows/update_helm_index.yml
@@ -17,7 +17,6 @@ jobs:
         path: website
         token: ${{ secrets.ANTREA_BOT_PAT }}
     - name: Wait for exclusive access
-      working-directory: website
       uses: ben-z/gh-action-mutex@v1.0-alpha-5
       with:
           branch: needs_to_commit-mutex


### PR DESCRIPTION
The "working-directory" attribute cannot be used with "uses".

Signed-off-by: Antonin Bas <abas@vmware.com>