### PR TITLE
Add artifacthub metadata file

### DIFF
--- a/static/charts/artifacthub-repo.yml
+++ b/static/charts/artifacthub-repo.yml
@@ -1,0 +1,10 @@
+# Artifact Hub repository metadata file
+repositoryID: 572652f4-28e8-461b-bd37-ce6a1ee45126
+# optional, packages that should not be indexed by Artifact Hub
+ignore:
+  - name: antrea
+    version: '^.*\-rc.*$'
+  - name: flow-aggregator
+    version: '^.*\-rc.*$'
+  - name: theia
+    version: '^.*\-rc.*$'


### PR DESCRIPTION
artifacthub-repo.yml

It needs to be at the same location as the Helm repo index (index.yaml).

Signed-off-by: Antonin Bas <abas@vmware.com>