### PR TITLE
Prevent failures for concurrent update_helm_index workflows

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -16,6 +16,12 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
+    - name: Wait for exclusive access
+      uses: ben-z/gh-action-mutex@v1.0-alpha-5
+      with:
+        repo-token: ${{ secrets.ANTREA_BOT_PAT }}
+        repository: antrea-io/website
+        branch: needs_to_commit-mutex
     - name: Checkout Antrea
       uses: actions/checkout@v2
       with:
@@ -25,12 +31,9 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@v2
       with:
+        ref: main
         path: website
         token: ${{ secrets.ANTREA_BOT_PAT }}
-    - name: Wait for exclusive access
-      uses: ben-z/gh-action-mutex@v1.0-alpha-5
-      with:
-          branch: needs_to_commit-mutex
     - name: Install golang
       uses: actions/setup-go@v2
       with:
@@ -49,10 +52,9 @@ jobs:
       run: |
         ./website/scripts/bin/freeze-version-docs -antrea-repo antrea -website-repo website -version $TAG
     - name: Commit changes as antrea-bot
-      uses: EndBug/add-and-commit@v7
+      uses: EndBug/add-and-commit@v9
       with:
         cwd: ./website
         author_name: antrea-bot
         author_email: antreabot@gmail.com
         message: "Website update for ${{ github.event.inputs.antrea-ref }}"
-        signoff: false

--- a/.github/workflows/update_helm_index.yml
+++ b/.github/workflows/update_helm_index.yml
@@ -11,25 +11,27 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout repo
-      uses: actions/checkout@v2
-      with:
-        path: website
-        token: ${{ secrets.ANTREA_BOT_PAT }}
     - name: Wait for exclusive access
       uses: ben-z/gh-action-mutex@v1.0-alpha-5
       with:
-          branch: needs_to_commit-mutex
+        repo-token: ${{ secrets.ANTREA_BOT_PAT }}
+        repository: antrea-io/website
+        branch: needs_to_commit-mutex
+    - name: Checkout repo
+      uses: actions/checkout@v2
+      with:
+        ref: main
+        path: website
+        token: ${{ secrets.ANTREA_BOT_PAT }}
     - name: Update Helm index file
       env:
         ARCHIVE_URL: ${{ github.event.inputs.archive-url }}
       run: |
         ./website/scripts/update-helm-index.sh --website-repo website --archive-url $ARCHIVE_URL
     - name: Commit changes as antrea-bot
-      uses: EndBug/add-and-commit@v7
+      uses: EndBug/add-and-commit@v9
       with:
         cwd: ./website
         author_name: antrea-bot
         author_email: antreabot@gmail.com
         message: "Helm index update for ${{ github.event.inputs.archive-url }}"
-        signoff: false


### PR DESCRIPTION
The solution is to request exclusive access BEFORE checking out the
website repository. We also ensure that the latest version of main is
checked out, not the commit for which the workflow was triggered.

As part of this change, we update the EndBug/add-and-commit action to
the latest version. One important change is that starting with v8, the
action will now work with whatever ref has been checked out, without
pulling or switching branches by default.

Fixes #34

Signed-off-by: Antonin Bas <abas@vmware.com>