### PR TITLE
Add Traffic Control to ToC for main and v1.8.0

### DIFF
--- a/content/docs/main/docs/cookbooks/ids/_index.md
+++ b/content/docs/main/docs/cookbooks/ids/_index.md
@@ -1,0 +1,4 @@
+---
+---
+
+{{% include-md README.md %}}

--- a/content/docs/v1.8.0/docs/cookbooks/ids/_index.md
+++ b/content/docs/v1.8.0/docs/cookbooks/ids/_index.md
@@ -1,0 +1,4 @@
+---
+---
+
+{{% include-md README.md %}}

--- a/data/docs/main-toc.yml
+++ b/data/docs/main-toc.yml
@@ -63,6 +63,8 @@ toc:
         url: /docs/antrea-ipam
       - page: Exposing Services of type LoadBalancer
         url: /docs/service-loadbalancer
+      - page: Traffic Control
+        url: /docs/traffic-control
       - page: Versioning
         url: /docs/versioning
       - page: Antrea API Groups

--- a/data/docs/v1.8.0-toc.yml
+++ b/data/docs/v1.8.0-toc.yml
@@ -63,6 +63,8 @@ toc:
         url: /docs/antrea-ipam
       - page: Exposing Services of type LoadBalancer
         url: /docs/service-loadbalancer
+      - page: Traffic Control
+        url: /docs/traffic-control
       - page: Versioning
         url: /docs/versioning
       - page: Antrea API Groups


### PR DESCRIPTION
Also add missing _index.md to cookbooks/ids to ensure that links to it work as expected.