### PR TITLE
featureGate in Configmap instead of Deployment. And add helm value

### DIFF
--- a/content/docs/main/docs/antrea-ipam.md
+++ b/content/docs/main/docs/antrea-ipam.md
@@ -88,8 +88,14 @@ IPPool annotation, or when the `AntreaIPAM` feature is disabled.
 
 To enable flexible IPAM, you need to enable the `AntreaIPAM` feature gate for
 both `antrea-controller` and `antrea-agent`, and set the `enableBridgingMode`
-configuration parameter of `antrea-agent` to `true`. The needed changes in the
-Antrea deployment YAML are:
+configuration parameter of `antrea-agent` to `true`. When Antrea is installed 
+by helm, just simply modify the helm chart `values.yaml` as below:
+-  `enableBridgingMode: true`
+-  `featureGates: {AntreaIPAM: true}`
+-  `trafficEncapMode: "noEncap"`
+-  `noSNAT: true`
+Otherwise, if Antrea is installed from YAML: the needed changes in the Antrea
+configmap `antrea-config` YAML are as below:
 
 ```yaml
   antrea-controller.conf: |


### PR DESCRIPTION
To fix : original doc tells the featureGate and conf in deployment, but actually, it's inside configmap `antrea-config`.

To enhance: provides helm --set values when people install antrea by helm.

