### PR TITLE
Remove old Antrea versions from navigation drop-down

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,11 @@ antrea-io Github organization, you need to open a PR with the following changes:
  * add a new HTML file under `static/golang/`, e.g., `static/golang/<new repo
    name>.html`; add the necessary HTML content (look at existing files for
    reference)
+
+## Removing old versions
+
+When a version of Antrea is no longer supported, it is a good idea to remove it
+from the drop-down navigation menu, by editing `config.yaml`. The actual
+documentation does not need to be removed from the `contents/` directory, unless
+website size becomes an issue. In doing so, we ensure that old links will keep
+working, while also decluttering the website.

--- a/config.yaml
+++ b/config.yaml
@@ -58,13 +58,6 @@ params:
     - v1.2.2
     - v1.2.1
     - v1.2.0
-    - v1.1.2
-    - v1.1.1
-    - v1.1.0
-    - v1.0.3
-    - v1.0.0
-    - v0.13.5
-    - v0.13.0
 mediaTypes:
   "text/netlify":
     delimiter: ""


### PR DESCRIPTION
From 0.13 to 1.1 included.