### PR TITLE
Remove navigation link to Manual Installation document

### DIFF
--- a/data/docs/main-toc.yml
+++ b/data/docs/main-toc.yml
@@ -109,8 +109,6 @@ toc:
         url: /docs/contributors/issue-management
       - page: GitHub Labels
         url: /docs/contributors/github-labels
-      - page: Manual Installation
-        url: /docs/contributors/manual-installation
   - title: Project Information
     subfolderitems: 
     - page: Contributing to Antrea

--- a/data/docs/v1.10.0-toc.yml
+++ b/data/docs/v1.10.0-toc.yml
@@ -109,8 +109,6 @@ toc:
         url: /docs/contributors/issue-management
       - page: GitHub Labels
         url: /docs/contributors/github-labels
-      - page: Manual Installation
-        url: /docs/contributors/manual-installation
   - title: Project Information
     subfolderitems: 
     - page: Contributing to Antrea

--- a/data/docs/v1.10.1-toc.yml
+++ b/data/docs/v1.10.1-toc.yml
@@ -109,8 +109,6 @@ toc:
         url: /docs/contributors/issue-management
       - page: GitHub Labels
         url: /docs/contributors/github-labels
-      - page: Manual Installation
-        url: /docs/contributors/manual-installation
   - title: Project Information
     subfolderitems: 
     - page: Contributing to Antrea

--- a/data/docs/v1.11.0-alpha.0-toc.yml
+++ b/data/docs/v1.11.0-alpha.0-toc.yml
@@ -109,8 +109,6 @@ toc:
         url: /docs/contributors/issue-management
       - page: GitHub Labels
         url: /docs/contributors/github-labels
-      - page: Manual Installation
-        url: /docs/contributors/manual-installation
   - title: Project Information
     subfolderitems: 
     - page: Contributing to Antrea

--- a/data/docs/v1.11.0-toc.yml
+++ b/data/docs/v1.11.0-toc.yml
@@ -109,8 +109,6 @@ toc:
         url: /docs/contributors/issue-management
       - page: GitHub Labels
         url: /docs/contributors/github-labels
-      - page: Manual Installation
-        url: /docs/contributors/manual-installation
   - title: Project Information
     subfolderitems: 
     - page: Contributing to Antrea

--- a/data/docs/v1.11.1-toc.yml
+++ b/data/docs/v1.11.1-toc.yml
@@ -109,8 +109,6 @@ toc:
         url: /docs/contributors/issue-management
       - page: GitHub Labels
         url: /docs/contributors/github-labels
-      - page: Manual Installation
-        url: /docs/contributors/manual-installation
   - title: Project Information
     subfolderitems: 
     - page: Contributing to Antrea

--- a/data/docs/v1.11.2-toc.yml
+++ b/data/docs/v1.11.2-toc.yml
@@ -109,8 +109,6 @@ toc:
         url: /docs/contributors/issue-management
       - page: GitHub Labels
         url: /docs/contributors/github-labels
-      - page: Manual Installation
-        url: /docs/contributors/manual-installation
   - title: Project Information
     subfolderitems: 
     - page: Contributing to Antrea

--- a/data/docs/v1.12.0-toc.yml
+++ b/data/docs/v1.12.0-toc.yml
@@ -109,8 +109,6 @@ toc:
         url: /docs/contributors/issue-management
       - page: GitHub Labels
         url: /docs/contributors/github-labels
-      - page: Manual Installation
-        url: /docs/contributors/manual-installation
   - title: Project Information
     subfolderitems: 
     - page: Contributing to Antrea

--- a/data/docs/v1.12.1-toc.yml
+++ b/data/docs/v1.12.1-toc.yml
@@ -109,8 +109,6 @@ toc:
         url: /docs/contributors/issue-management
       - page: GitHub Labels
         url: /docs/contributors/github-labels
-      - page: Manual Installation
-        url: /docs/contributors/manual-installation
   - title: Project Information
     subfolderitems: 
     - page: Contributing to Antrea

--- a/data/docs/v1.7.0-toc.yml
+++ b/data/docs/v1.7.0-toc.yml
@@ -103,8 +103,6 @@ toc:
         url: /docs/contributors/issue-management
       - page: GitHub Labels
         url: /docs/contributors/github-labels
-      - page: Manual Installation
-        url: /docs/contributors/manual-installation
   - title: Project Information
     subfolderitems: 
     - page: Contributing to Antrea

--- a/data/docs/v1.7.1-toc.yml
+++ b/data/docs/v1.7.1-toc.yml
@@ -103,8 +103,6 @@ toc:
         url: /docs/contributors/issue-management
       - page: GitHub Labels
         url: /docs/contributors/github-labels
-      - page: Manual Installation
-        url: /docs/contributors/manual-installation
   - title: Project Information
     subfolderitems: 
     - page: Contributing to Antrea

--- a/data/docs/v1.7.2-toc.yml
+++ b/data/docs/v1.7.2-toc.yml
@@ -103,8 +103,6 @@ toc:
         url: /docs/contributors/issue-management
       - page: GitHub Labels
         url: /docs/contributors/github-labels
-      - page: Manual Installation
-        url: /docs/contributors/manual-installation
   - title: Project Information
     subfolderitems: 
     - page: Contributing to Antrea

--- a/data/docs/v1.7.3-toc.yml
+++ b/data/docs/v1.7.3-toc.yml
@@ -103,8 +103,6 @@ toc:
         url: /docs/contributors/issue-management
       - page: GitHub Labels
         url: /docs/contributors/github-labels
-      - page: Manual Installation
-        url: /docs/contributors/manual-installation
   - title: Project Information
     subfolderitems: 
     - page: Contributing to Antrea

--- a/data/docs/v1.8.0-alpha.0-toc.yml
+++ b/data/docs/v1.8.0-alpha.0-toc.yml
@@ -103,8 +103,6 @@ toc:
         url: /docs/contributors/issue-management
       - page: GitHub Labels
         url: /docs/contributors/github-labels
-      - page: Manual Installation
-        url: /docs/contributors/manual-installation
   - title: Project Information
     subfolderitems: 
     - page: Contributing to Antrea

--- a/data/docs/v1.8.0-alpha.1-toc.yml
+++ b/data/docs/v1.8.0-alpha.1-toc.yml
@@ -103,8 +103,6 @@ toc:
         url: /docs/contributors/issue-management
       - page: GitHub Labels
         url: /docs/contributors/github-labels
-      - page: Manual Installation
-        url: /docs/contributors/manual-installation
   - title: Project Information
     subfolderitems: 
     - page: Contributing to Antrea

--- a/data/docs/v1.8.0-alpha.2-toc.yml
+++ b/data/docs/v1.8.0-alpha.2-toc.yml
@@ -103,8 +103,6 @@ toc:
         url: /docs/contributors/issue-management
       - page: GitHub Labels
         url: /docs/contributors/github-labels
-      - page: Manual Installation
-        url: /docs/contributors/manual-installation
   - title: Project Information
     subfolderitems: 
     - page: Contributing to Antrea

--- a/data/docs/v1.8.0-toc.yml
+++ b/data/docs/v1.8.0-toc.yml
@@ -109,8 +109,6 @@ toc:
         url: /docs/contributors/issue-management
       - page: GitHub Labels
         url: /docs/contributors/github-labels
-      - page: Manual Installation
-        url: /docs/contributors/manual-installation
   - title: Project Information
     subfolderitems: 
     - page: Contributing to Antrea

--- a/data/docs/v1.8.1-toc.yml
+++ b/data/docs/v1.8.1-toc.yml
@@ -109,8 +109,6 @@ toc:
         url: /docs/contributors/issue-management
       - page: GitHub Labels
         url: /docs/contributors/github-labels
-      - page: Manual Installation
-        url: /docs/contributors/manual-installation
   - title: Project Information
     subfolderitems: 
     - page: Contributing to Antrea

--- a/data/docs/v1.9.0-toc.yml
+++ b/data/docs/v1.9.0-toc.yml
@@ -109,8 +109,6 @@ toc:
         url: /docs/contributors/issue-management
       - page: GitHub Labels
         url: /docs/contributors/github-labels
-      - page: Manual Installation
-        url: /docs/contributors/manual-installation
   - title: Project Information
     subfolderitems: 
     - page: Contributing to Antrea

--- a/data/docs/v1.9.1-toc.yml
+++ b/data/docs/v1.9.1-toc.yml
@@ -109,8 +109,6 @@ toc:
         url: /docs/contributors/issue-management
       - page: GitHub Labels
         url: /docs/contributors/github-labels
-      - page: Manual Installation
-        url: /docs/contributors/manual-installation
   - title: Project Information
     subfolderitems: 
     - page: Contributing to Antrea


### PR DESCRIPTION
The document no longer exists in Antrea versions v1.7 and up.

Fixes #47